### PR TITLE
[공통] gradle 버전 downgrade

### DIFF
--- a/untact-test-sample/gradle/wrapper/gradle-wrapper.properties
+++ b/untact-test-sample/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- [x] gradle 8.1.1 -> 7.6.1

사유: jacoco 속성 적용되지 않는 이슈

`xml.enabled true` 에서 enabled 속성을 찾을 수 없음